### PR TITLE
Rewrite double hashing algo again, to fix cycle of length size issue

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -68,30 +68,6 @@ export function hashTwice(
 }
 
 /**
- * Apply Double Hashing to produce a n-hash
- *
- * This implementation used directly the value produced by the two hash functions instead of the functions themselves.
- * @see {@link http://citeseer.ist.psu.edu/viewdoc/download;jsessionid=4060353E67A356EF9528D2C57C064F5A?doi=10.1.1.152.579&rep=rep1&type=pdf} for more details about double hashing.
- * @param  n - The indice of the hash function we want to produce
- * @param  hashA - The result of the first hash function applied to a value.
- * @param  hashB - The result of the second hash function applied to a value.
- * @param  size - The size of the datastructures associated to the hash context (ex: the size of a Bloom Filter)
- * @return The result of hash_n applied to a value.
- * @memberof Utils
- * @author Thomas Minier
- */
-export function doubleHashing(
-  n: number,
-  hashA: number,
-  hashB: number,
-  size: number
-): number {
-  // Cubic term avoids increased-probability-of-collision issue, see
-  // http://peterd.org/pcd-diss.pdf s.6.5.4
-  return Math.abs((hashA + n*hashB + Math.floor((n**3 - n)/6)) % size);
-}
-
-/**
  * Generate a set of distinct indexes on interval [0, size) using the double hashing technique
  * @param  element  - The element to hash
  * @param  size     - the range on which we can generate an index [0, size) = size

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -1,0 +1,18 @@
+'use strict';
+
+require('chai').should();
+const Utils = require('../dist/utils.js');
+
+describe('getDistinctIndices', () => {
+  it('should take a reasonable number of iterations with pathological inputs', () => {
+    // construct inputs which make it quite likely that h_2 is coprime with the size, we
+    // should not get into a loop
+    const size = 7;
+    const numIndexes = 7;
+    const seed = 0;
+    const maxIterations = 100;
+    for(let i=0; i<1000; i++) {
+      Utils.getDistinctIndices(i.toString(), size, numIndexes, seed, maxIterations);
+    }
+  });
+});


### PR DESCRIPTION
Enhanced double hashing stops cycles of length less than `size` in the case where size is coprime with the second hash. But you still get cycles of length `size`.  So if we reach there and haven't finished, append a prime to the input and rehash.

Also fix poorly implemented cubic term: interpreted (n^3 - n)/6 mod m wrongly (division should have been mult inverse under mod m, not integer floor division). Reimplemented correctly.

I think this should now be both efficient and resilient against pathological inputs.